### PR TITLE
Fix self.IDs and helper(pars) input

### DIFF
--- a/NIRCAM_Gsim/observations/observations.py
+++ b/NIRCAM_Gsim/observations/observations.py
@@ -118,6 +118,8 @@ class observation():
                     self.xs.append(xs)
                     self.ys.append(ys)
                     self.IDs = all_IDs
+            if len(all_IDs) == 0:
+                self.IDs = []
         else:
             vg = self.seg==self.ID
             ys,xs = np.nonzero(vg)            
@@ -151,7 +153,6 @@ class observation():
                 d = fits.open(dir_image)[1].data
             except:
                 d = fits.open(dir_image)[0].data
-
 
             # If we do not use an SED file then we use photometry to get fluxes
             # Otherwise, we assume that objects are normalized to 1.
@@ -347,7 +348,7 @@ class observation():
             ID = 1
             xs0 = [xs[i],xs[i]+1,xs[i]+1,xs[i]]
             ys0 = [ys[i],ys[i],ys[i]+1,ys[i]+1]
-            pars.append([xs0,ys0,f,self.order,C,ID,False])
+            pars.append([xs0,ys0,f,self.order,C,ID,False,0.0,0.0])
             
 
         from multiprocessing import Pool
@@ -358,6 +359,7 @@ class observation():
         mypool.close()
 
         bck = np.zeros(naxis,np.float)
+                
         for i,pp in enumerate(all_res, 1): 
             if np.shape(pp.transpose())==(1,6):
                 continue


### PR DESCRIPTION
**Please check carefully that these changes don't break other things!!**

This is a quick fix two errors I had when running the NIRCam_TSO_examples Jupyter Notebook. Sorry I didn't save all errors because this step takes >30 min to run.

1. If there are no non-zero pixels in the segment map, self.IDs was undefined. I set it to be [] if all_IDs also has a length of 0.

2. `observations.helper` expects 9 variables but is only fed 7 (no `xoffset` or `yoffset`). I set both of them to 0.0 in pars but am not 100% sure you want them always to be 0.0